### PR TITLE
Sync using 'upload_folder' + add private attribute

### DIFF
--- a/.github/workflows/sync_with_hf_hub.yml
+++ b/.github/workflows/sync_with_hf_hub.yml
@@ -18,6 +18,9 @@ on:
       space_sdk:
         type: string
         default: 'gradio'
+      private:
+        type: boolean
+        default: false
     secrets:
       hf_token:
         required: true
@@ -57,4 +60,5 @@ jobs:
             --directory "cloned_github_repo/${{ inputs.subdirectory }}" \
             --token ${{ secrets.hf_token }} \
             --repo_type ${{ inputs.repo_type }} \
-            --space_sdk ${{ inputs.space_sdk }}
+            --space_sdk ${{ inputs.space_sdk }} \
+            --private ${{ inputs.private }}

--- a/sync_with_spaces.py
+++ b/sync_with_spaces.py
@@ -1,46 +1,44 @@
-from pathlib import Path
-from huggingface_hub import upload_file, create_repo
+from huggingface_hub import create_repo, upload_folder, whoami
+
 
 def main(
-    repo_id,
-    directory,
-    token,
-    repo_type='space',
-    space_sdk='gradio',
+    repo_id: str,
+    directory: str,
+    token: str,
+    repo_type: str = "space",
+    space_sdk: str = "gradio",
+    private: bool = False,
 ):
     print("Syncing with Hugging Face Spaces...")
+
+    if "/" not in repo_id:
+        # Case namespace is implicit
+        username = whoami(token=token)["name"]
+        repo_id = f"{username}/{repo_id}"
     print(f"\t- Repo ID: {repo_id}")
+
     print(f"\t- Directory: {directory}")
     url = create_repo(
         repo_id,
         token=token,
         exist_ok=True,
         repo_type=repo_type,
-        space_sdk=space_sdk if repo_type == 'space' else None
+        space_sdk=space_sdk if repo_type == "space" else None,
+        private=private,
     )
     print(f"\t- Repo URL: {url}")
-    for filepath in Path(directory).glob("**/*"):
 
-        if not filepath.is_file():
-            continue
+    # Sync folder
+    commit_url = upload_folder(
+        folder_path=directory,
+        repo_id=repo_id,
+        repo_type=repo_type,
+        token=token,
+        commit_message="Synced repo using 'sync_with_huggingface' Github Action",
+        ignore_patterns=["*.git*", "*README.md*"],
+    )
+    print(f"\t- Repo synced: {commit_url}")
 
-        if ".git" in str(filepath):
-            print(f"\t\t- Skipping {filepath} because it is in .git directory")
-            continue
-
-        if filepath.name == "README.md":
-            print(f"\t\t- Skipping {filepath} because it is a GitHub README")
-            continue
-
-        path_in_repo = str(filepath.relative_to(Path(directory)))
-        print(f"\t\t- Uploading '{filepath}' to '{path_in_repo}'")
-        upload_file(
-            path_or_fileobj=str(filepath),
-            path_in_repo=path_in_repo,
-            token=token,
-            repo_id=repo_id,
-            repo_type=repo_type,
-        )
 
 if __name__ == "__main__":
     from fire import Fire


### PR DESCRIPTION
@nateraw I made a few changes/fixes if that's fine with you. Love the idea of this Github Action btw :fire:.
1. `private` argument was described in README but not effective in the github action
2. `repo_id` can be misleading if username is implicit => I still wonder how we could ease this in `huggingface_hub`
3. Use `upload_folder` with `ignore_patterns` to filter `README` and `.git` files. Makes implementation cleaner + only 1 commit is pushed to HF instead of 1 per file.

Not done in the PR but I guess it could be interesting to add more options in the GH action like `create_pr`, `revision`, `ignore_patterns`. Let's see if it's requested by community :)