### PR TITLE
feature: Support Git metadata, README sync, skip checkout, and action testing

### DIFF
--- a/.github/workflows/hf-space-sync.yml
+++ b/.github/workflows/hf-space-sync.yml
@@ -1,0 +1,28 @@
+
+name: HuggingFace Space Sync
+
+on:
+  push:
+    branches:
+      - 'main'
+      - 'feature/test-action'
+
+jobs:
+  push-hf-space:
+    name: Push source code to HuggingFace
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Sync Gradio space to HuggingFace
+        uses: ./
+        with:
+          github_repo_id: '${{ github.repository_owner }}/huggingface-sync-action'
+          huggingface_repo_id: '${{ secrets.HF_USERNAME }}/huggingface-sync-action-gradio'
+          hf_token: ${{ secrets.HF_TOKEN }}
+          private: true
+          repo_type: 'space'
+          space_sdk: 'gradio'
+          subdirectory: 'test/gradio'

--- a/.github/workflows/hf-space-sync.yml
+++ b/.github/workflows/hf-space-sync.yml
@@ -37,3 +37,15 @@ jobs:
           repo_type: 'space'
           space_sdk: 'gradio'
           subdirectory: 'test/gradio'
+
+      - name: Sync README file Gradio space to HuggingFace
+        uses: ./
+        with:
+          # repo_path: '.'
+          huggingface_repo_id: '${{ secrets.HF_USERNAME }}/huggingface-sync-action-gradio'
+          hf_token: ${{ secrets.HF_TOKEN }}
+          private: true
+          repo_type: 'space'
+          space_sdk: 'gradio'
+          subdirectory: 'test/gradio'
+          include_readme: true

--- a/.github/workflows/hf-space-sync.yml
+++ b/.github/workflows/hf-space-sync.yml
@@ -49,3 +49,16 @@ jobs:
           space_sdk: 'gradio'
           subdirectory: 'test/gradio'
           include_readme: true
+
+      - name: Sync Git info Gradio space to HuggingFace
+        uses: ./
+        with:
+          # repo_path: '.'
+          huggingface_repo_id: '${{ secrets.HF_USERNAME }}/huggingface-sync-action-gradio'
+          hf_token: ${{ secrets.HF_TOKEN }}
+          private: true
+          repo_type: 'space'
+          space_sdk: 'gradio'
+          subdirectory: 'test/gradio'
+          include_readme: true
+          generate_message: true

--- a/.github/workflows/hf-space-sync.yml
+++ b/.github/workflows/hf-space-sync.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches:
       - 'main'
-      - 'feature/test-action'
+      - 'feature/**'
 
 jobs:
   push-hf-space:
@@ -16,7 +16,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Sync Gradio space to HuggingFace
+      - name: Sync local repo Gradio space to HuggingFace
+        uses: ./
+        with:
+          # repo_path: '.'
+          huggingface_repo_id: '${{ secrets.HF_USERNAME }}/huggingface-sync-action-gradio'
+          hf_token: ${{ secrets.HF_TOKEN }}
+          private: true
+          repo_type: 'space'
+          space_sdk: 'gradio'
+          subdirectory: 'test/gradio'
+
+      - name: Sync Github repo Gradio space to HuggingFace
         uses: ./
         with:
           github_repo_id: '${{ github.repository_owner }}/huggingface-sync-action'

--- a/action.yml
+++ b/action.yml
@@ -10,11 +10,14 @@ inputs:
     description: Repository Path for sync
     default: '.'
   github_repo_id:
-    description: GitHub repo ID to sync
+    description: GitHub repo ID for sync
     default: ''
   subdirectory:
-    description: Subdirectory to sync
+    description: Subdirectory for sync
     default: ''
+  include_readme:
+    description: Include README.md for sync
+    default: 'False'
   huggingface_repo_id:
     description: Hugging Face repo ID to sync
     required: true
@@ -61,4 +64,5 @@ runs:
           --token ${{ inputs.hf_token }} \
           --repo_type ${{ inputs.repo_type }} \
           --space_sdk ${{ inputs.space_sdk }} \
-          --private ${{ (inputs.private == true || inputs.private == 'true' || inputs.private == 'True') && 'True' || 'False' }}
+          --private ${{ (inputs.private == true || inputs.private == 'true' || inputs.private == 'True') && 'True' || 'False' }} \
+          --include_readme ${{ (inputs.include_readme == true || inputs.include_readme == 'true' || inputs.include_readme == 'True') && 'True' || 'False' }}

--- a/action.yml
+++ b/action.yml
@@ -6,26 +6,30 @@ branding:
   color: yellow
 
 inputs:
+  repo_path:
+    description: Repository Path for sync
+    default: '.'
   github_repo_id:
-    required: true
-    type: string
+    description: GitHub repo ID to sync
+    default: ''
   subdirectory:
-    type: string
+    description: Subdirectory to sync
     default: ''
   huggingface_repo_id:
+    description: Hugging Face repo ID to sync
     required: true
-    type: string
   hf_token:
+    description: Hugging Face token
     required: true
   repo_type:
-    type: string
+    description: Hugging Face repo type
     default: 'space'
   space_sdk:
-    type: string
+    description: Hugging Face Space SDK to use
     default: 'gradio'
   private:
-    type: boolean
-    default: false
+    description: Hugging Face repo private
+    default: 'False'
 
 runs:
   using: "composite"
@@ -37,6 +41,7 @@ runs:
         path: cloned_hf_action_repo
 
     - name: Checkout Source GitHub Repo to Push
+      if: ${{ inputs.github_repo_id != '' }}
       uses: actions/checkout@v4
       with:
         repository: '${{ inputs.github_repo_id }}'
@@ -52,8 +57,8 @@ runs:
         cd ..
         python cloned_hf_action_repo/sync_with_spaces.py \
           --repo_id ${{ inputs.huggingface_repo_id }} \
-          --directory "cloned_github_repo/${{ inputs.subdirectory }}" \
+          --directory "${{ inputs.github_repo_id != '' && format('cloned_github_repo/{0}', inputs.subdirectory) || format('{0}/{1}', inputs.repo_path, inputs.subdirectory) }}" \
           --token ${{ inputs.hf_token }} \
           --repo_type ${{ inputs.repo_type }} \
           --space_sdk ${{ inputs.space_sdk }} \
-          --private ${{ inputs.private == 'true' && 'True' || 'False' }}
+          --private ${{ (inputs.private == true || inputs.private == 'true' || inputs.private == 'True') && 'True' || 'False' }}

--- a/action.yml
+++ b/action.yml
@@ -56,4 +56,4 @@ runs:
           --token ${{ inputs.hf_token }} \
           --repo_type ${{ inputs.repo_type }} \
           --space_sdk ${{ inputs.space_sdk }} \
-          --private ${{ inputs.private }}
+          --private ${{ inputs.private == 'true' && 'True' || 'False' }}

--- a/action.yml
+++ b/action.yml
@@ -37,12 +37,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Checkout Action GitHub Repo
-      uses: actions/checkout@v4
-      with:
-        repository: 'nateraw/spaces-action'
-        path: cloned_hf_action_repo
-
     - name: Checkout Source GitHub Repo to Push
       if: ${{ inputs.github_repo_id != '' }}
       uses: actions/checkout@v4
@@ -54,11 +48,8 @@ runs:
     - name: Push to hub
       shell: bash
       run: |
-        cd cloned_hf_action_repo
-        git pull origin main
         pip install -r requirements.txt
-        cd ..
-        python cloned_hf_action_repo/sync_with_spaces.py \
+        python sync_with_spaces.py \
           --repo_id ${{ inputs.huggingface_repo_id }} \
           --directory "${{ inputs.github_repo_id != '' && format('cloned_github_repo/{0}', inputs.subdirectory) || format('{0}/{1}', inputs.repo_path, inputs.subdirectory) }}" \
           --token ${{ inputs.hf_token }} \

--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,9 @@ inputs:
   include_readme:
     description: Include README.md for sync
     default: 'False'
+  generate_message:
+    description: Generate commit message for sync
+    default: 'False'
   huggingface_repo_id:
     description: Hugging Face repo ID to sync
     required: true
@@ -56,4 +59,5 @@ runs:
           --repo_type ${{ inputs.repo_type }} \
           --space_sdk ${{ inputs.space_sdk }} \
           --private ${{ (inputs.private == true || inputs.private == 'true' || inputs.private == 'True') && 'True' || 'False' }} \
-          --include_readme ${{ (inputs.include_readme == true || inputs.include_readme == 'true' || inputs.include_readme == 'True') && 'True' || 'False' }}
+          --include_readme ${{ (inputs.include_readme == true || inputs.include_readme == 'true' || inputs.include_readme == 'True') && 'True' || 'False' }} \
+          --generate_message ${{ (inputs.generate_message == true || inputs.generate_message == 'true' || inputs.generate_message == 'True') && 'True' || 'False' }}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 huggingface_hub==0.12.0
 fire==0.4.0
+GitPython==3.1.44

--- a/sync_with_spaces.py
+++ b/sync_with_spaces.py
@@ -8,6 +8,7 @@ def main(
     repo_type: str = "space",
     space_sdk: str = "gradio",
     private: bool = False,
+    include_readme: bool = False
 ):
     print("Syncing with Hugging Face Spaces...")
 
@@ -29,13 +30,16 @@ def main(
     print(f"\t- Repo URL: {url}")
 
     # Sync folder
+    ignore_patterns = ["*.git*", "*README.md*"]
+    if include_readme:
+        ignore_patterns.remove("*README.md*")
     commit_url = upload_folder(
         folder_path=directory,
         repo_id=repo_id,
         repo_type=repo_type,
         token=token,
         commit_message="Synced repo using 'sync_with_huggingface' Github Action",
-        ignore_patterns=["*.git*", "*README.md*"],
+        ignore_patterns=ignore_patterns
     )
     print(f"\t- Repo synced: {commit_url}")
 

--- a/sync_with_spaces.py
+++ b/sync_with_spaces.py
@@ -1,5 +1,7 @@
 from huggingface_hub import create_repo, upload_folder, whoami
-
+from git import Repo
+import textwrap
+import os
 
 def main(
     repo_id: str,
@@ -8,7 +10,8 @@ def main(
     repo_type: str = "space",
     space_sdk: str = "gradio",
     private: bool = False,
-    include_readme: bool = False
+    include_readme: bool = False,
+    generate_message: bool = False
 ):
     print("Syncing with Hugging Face Spaces...")
 
@@ -33,16 +36,39 @@ def main(
     ignore_patterns = ["*.git*", "*README.md*"]
     if include_readme:
         ignore_patterns.remove("*README.md*")
+    commit_message = generate_commit_message(generate_message, directory)
     commit_url = upload_folder(
         folder_path=directory,
         repo_id=repo_id,
         repo_type=repo_type,
         token=token,
-        commit_message="Synced repo using 'sync_with_huggingface' Github Action",
+        commit_message=commit_message,
         ignore_patterns=ignore_patterns
     )
     print(f"\t- Repo synced: {commit_url}")
 
+def generate_commit_message(generate_message: bool, directory: str):
+    commit_message = "Synced repo using 'sync_with_huggingface' Github Action"
+    if generate_message:
+        try:
+            repo = Repo(directory, search_parent_directories=True)
+            remote_url = repo.remotes.origin.url
+            commit_id = repo.head.commit.hexsha
+            action_repository = os.getenv("GITHUB_ACTION_REPOSITORY", "Unknown")
+            action_ref = os.getenv("GITHUB_ACTION_REF", "Unknown")
+            return textwrap.dedent(f"""\
+                {commit_message}
+
+                original:
+                    - remote: "{remote_url}"
+                    - commit: "{commit_id}"
+                sync_with_huggingface:
+                    - repository: "{action_repository}"
+                    - ref: "{action_ref}"
+            """)
+        except Exception as e:
+            print(f"Failed to generate commit message: {e}")
+    return commit_message
 
 if __name__ == "__main__":
     from fire import Fire

--- a/test/gradio/README.md
+++ b/test/gradio/README.md
@@ -1,0 +1,12 @@
+---
+title: huggingface-sync-action
+emoji: 🧪
+colorFrom: pink
+colorTo: purple
+sdk: gradio
+sdk_version: 5.34.2
+app_file: app.py
+pinned: false
+---
+
+Check out the configuration reference at https://huggingface.co/docs/hub/spaces-config-reference


### PR DESCRIPTION
This PR introduces the following improvements to the sync_with_huggingface GitHub Action:

- Support syncing README.md
When --include_readme=true is specified, the action will upload the local README.md file to the target repository.

- Attach Git commit metadata to the commit message
If the input directory is a valid Git repository, the action will append the following metadata to the commit message:
    - Original repository remote URL and commit SHA
    - The sync_with_huggingface action's repository and ref information

- Allow skipping GitHub repository checkout
If the github_repo_id input is not set, the action will skip the actions/checkout step. It will use the repo_path directory instead, enabling reuse of externally cloned repositories.

- Support action-level testing
Adds a GitHub Actions workflow to test the action.
To run it, you must configure the following repository secrets or variables:

    - HF_USERNAME
    - HF_TOKEN